### PR TITLE
Keep the Why: migrate to 0.11.0 and add ktw-lint CI

### DIFF
--- a/.github/workflows/ktw-lint.yml
+++ b/.github/workflows/ktw-lint.yml
@@ -1,0 +1,17 @@
+name: ktw-lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  ktw-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oliver-zehentleitner/keep-the-why@lint-latest   # or @lint-v<version> to pin the action
+        with:
+          path: "."
+          strict: "false"    # "true" turns warnings (e.g. missing Type on old entries) into failures
+          # version: "0.11.0.0"   # optional: pin the linter itself; @lint-v<version> above pins only the wrapper

--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
-CLAUDE.md
+/CLAUDE.md
 
 AGENTS.local.md

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -1,0 +1,12 @@
+This is machine-readable project state for the Keep the Why skill
+(https://keepthewhy.com). See context/index.md, or this project's own
+README, for what Keep the Why actually is.
+
+<!-- keep-the-why:config -->
+- id: oliver-zehentleitner---unicorn-binance-suite
+- context: `context/`
+- init: complete
+- context-schema: 0.11.0
+- capture-confirmation: confirm-when-unsure
+- source-reference: never
+<!-- /keep-the-why:config -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,9 +119,5 @@ Why this exact order, the conda-forge indexing wait, and recurring release pitfa
 - Meta-package has no source code; any "bug" is really in one of the six modules.
 - Packaging/dependency gotchas (meta.yaml, channels, the Sphinx `'lucit': True` flag): see [`context/packaging.md`](context/packaging.md).
 
-<!-- keep-the-why:config -->
-- context: `context/`
-- init: complete
-- context-schema: 0.9.0
-- capture-confirmation: confirm-when-unsure
-<!-- /keep-the-why:config -->
+Keep the Why's config for this project migrated to .keep-the-why on
+2026-09-04 — requires skill version 0.10.0 or later to read it.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/unicorn_binance_suite.svg)](https://www.python.org/downloads/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/unit-tests.yml)
+[![ktw-lint](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/ktw-lint.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/ktw-lint.yml)
 [![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-suite/actions/workflows/build_wheels.yml)
 [![Conda-Forge Build](https://github.com/conda-forge/unicorn-binance-suite-feedstock/actions/workflows/conda-build.yml/badge.svg?branch=main)](https://github.com/conda-forge/unicorn-binance-suite-feedstock/actions/workflows/conda-build.yml)
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-suite/)

--- a/context/AGENTS.md
+++ b/context/AGENTS.md
@@ -1,0 +1,1 @@
+Before creating or editing anything in this directory, invoke the keep-the-why skill. Don't write to the schema by hand.

--- a/context/CLAUDE.md
+++ b/context/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/context/history.md
+++ b/context/history.md
@@ -2,8 +2,10 @@
 
 ## LUCIT branding/licensing removal (April 2026)
 
+> Superseded — LUCIT is fully removed as of this cleanup round.
+
 **Type:** decision
-**Status:** superseded — LUCIT is fully removed as of this cleanup round
+**Status:** superseded
 **Evidence:** confirmed
 **Source:** commits `83cc723`, `af0a4bf`, `c32edb2`, `097de55`, and others across April 2026
 

--- a/context/index.md
+++ b/context/index.md
@@ -1,6 +1,6 @@
 # Context index
 
-- [release-workflow.md](release-workflow.md) — why releases across the suite follow a strict dependency order, and the recurring pitfalls that order exists to avoid
 - [dependency-management.md](dependency-management.md) — why deps are duplicated across 5 files instead of one source, and the pin-timing rule
-- [packaging.md](packaging.md) — conda/meta.yaml boundaries, why there's no in-repo conda build, the Sphinx theme flag
 - [history.md](history.md) — the 2026 LUCIT branding/licensing removal
+- [packaging.md](packaging.md) — conda/meta.yaml boundaries, why there's no in-repo conda build, the Sphinx theme flag
+- [release-workflow.md](release-workflow.md) — why releases across the suite follow a strict dependency order, and the recurring pitfalls that order exists to avoid

--- a/context/release-workflow.md
+++ b/context/release-workflow.md
@@ -40,10 +40,13 @@ The conda-forge autotick bot opens pin-bump PRs in downstream feedstocks automat
 
 ## Recurring pitfalls (not bugs, expected friction)
 
+**Type:** workaround
+**Status:** active
+**Evidence:** confirmed
+**Source:** all of the above validated during the April 2026 (2026-04-18/19) suite-wide cleanup release round
+
 - **CDN-cache race:** a feedstock PR's own CI goes green, but the subsequent main-branch build goes red on the same `meta.yaml` roughly a minute later. Not a real regression — the fix is a new build-number bump and retry. Most likely right after suite deps were just freshly published, before the CDN has caught up.
 - **Parallel pin-PR conflicts:** two bump PRs open at once both touch the same `CHANGELOG.md` `X.X.dev` block; merging one requires rebasing the other.
 - **Partial Azure builds:** if Azure (Windows/Mac) fails with transient git-fetch errors while Linux is green, the package can land incomplete in the channel. Fix: a new PR bumping `build.number` plus an explicit `@conda-forge-admin, please rerender` comment (the rerender request must be a comment, not text in the PR body — it isn't executed there).
 - **Python 3.14 migration silently reverts:** once a feedstock has been converted from `noarch: python` to a compiled build (Cython), a plain rerender can *delete* the existing `.ci_support/*python3.14*` files instead of regenerating them, because conda-smithy falls back to global pinning defaults without an active migration file. Fix: ensure `.ci_support/migrations/python314.yaml` exists in the feedstock (copy from conda-forge's `conda-forge-pinning-feedstock` migrations, or from `unicorn-binance-websocket-api-feedstock` which already has it), commit it, then rerender. Check for this file on every UBS feedstock bump — it's easy to lose 3.14 support silently on a routine rerender otherwise.
 - **Autotick bot opens a redundant version-bump PR in parallel** with a manual one — just close it (requires maintainer, the AIgent account has no close rights on those repos).
-
-**Evidence:** all of the above validated during the April 2026 (2026-04-18/19) suite-wide cleanup release round.


### PR DESCRIPTION
Suite-wide Keep the Why migration to schema **0.11.0**, plus the structural linter in CI.

**Migrations applied (per `references/migrations.md`)**

- **0.10.0 – dedicated config file:** the `<!-- keep-the-why:config -->` block moves from `AGENTS.md` into `.keep-the-why`. Every existing field is carried over verbatim; new `id` field (`oliver-zehentleitner---<repo>`, derived from the canonical upstream remote, not the fork), and `source-reference` backfilled to its documented default `never`. `AGENTS.md` keeps only the one-line migration note the migration guide asks for.
- **0.10.0 – guard files:** `context/AGENTS.md` + `context/CLAUDE.md`. Where `.gitignore` had an unanchored `CLAUDE.md` pattern it is now `/CLAUDE.md`, so the root file stays local and the nested guard file is tracked.
- **0.10.0 – `context/index.md` sorted alphabetically** (where it wasn't already).
- **0.11.0 – rule renumbering:** checked, no living document in this repo cites a remapped rule number.
- **0.11.0 – CI linting:** `.github/workflows/ktw-lint.yml`, the wizard snippet with `branches: [ master ]` to match the other workflows here. Non-strict by default; `@lint-latest` follows linter publishes.

**Linter-driven cleanups in `context/`**

`ktw-lint --strict` flagged header values outside the documented set. Normalized without dropping information: a trailing reason on `**Status:** superseded — …` moves into a `> Superseded — …` note directly under the entry heading (the same pattern keep-the-why's own `context/` uses); redundant suffixes on `open`/`active` entries (already stated in the entry body, Type reason or Source line) are dropped. See the diff for the exact lines.

**Verification**

- `ktw-lint . --strict` (0.11.0.0): 0 errors, 0 warnings, context-schema 0.11.0.
- Not done here: nothing personal (`AGENTS.local.md` is untracked, `~/.keep-the-why/<id>.md` is per developer), no `personal-defaults` block (optional, project's call).

**Follow-up commit:** `ktw-lint` workflow badge added to `README.md`, directly after the Unit Tests badge.
