### PR TITLE
Migrate keep-the-why context-schema 0.11.0 -> 0.13.2

### DIFF
--- a/.github/workflows/ktw-lint.yml
+++ b/.github/workflows/ktw-lint.yml
@@ -10,8 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oliver-zehentleitner/keep-the-why@lint-latest   # or @lint-v<version> to pin the action
+      - uses: oliver-zehentleitner/keep-the-why@lint-latest   # rolling; @lint-v<version> pins action and linter together
         with:
           path: "."
           strict: "false"    # "true" turns warnings (e.g. missing Type on old entries) into failures
-          # version: "0.11.0.0"   # optional: pin the linter itself; @lint-v<version> above pins only the wrapper
+          # version: "latest"     # only to mix: a pinned ref with a rolling linter, or vice versa — https://keepthewhy.com/linting/#versions-and-pinning

--- a/.keep-the-why
+++ b/.keep-the-why
@@ -6,7 +6,7 @@ README, for what Keep the Why actually is.
 - id: oliver-zehentleitner---unicorn-binance-suite
 - context: `context/`
 - init: complete
-- context-schema: 0.11.0
+- context-schema: 0.13.2
 - capture-confirmation: confirm-when-unsure
 - source-reference: never
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -25,7 +25,7 @@ For usage, installation, operation, or troubleshooting, see `docs/`.
 Each entry separates:
 
 - **Type** — what kind of thing it is: decision, workaround, incident, or constraint (or undefined, with a reason, if none fit)
-- **Status** — whether a decision is active, superseded, open, or needs review
+- **Status** — whether a decision is active, superseded, open, needs review, or still waits for a first confirmation
 - **Evidence** — whether its rationale is confirmed, inferred, or unknown
 
 Old reasoning is retained when it remains useful for understanding how the

--- a/context/index.md
+++ b/context/index.md
@@ -1,6 +1,81 @@
 # Context index
 
+## 0
+
+## 1
+
+## 2
+
+## 3
+
+## 4
+
+## 5
+
+## 6
+
+## 7
+
+## 8
+
+## 9
+
+## A
+
+## B
+
+## C
+
+## D
+
 - [dependency-management.md](dependency-management.md) — why deps are duplicated across 5 files instead of one source, and the pin-timing rule
+
+## E
+
+## F
+
+## G
+
+## H
+
 - [history.md](history.md) — the 2026 LUCIT branding/licensing removal
+
+## I
+
+## J
+
+## K
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
 - [packaging.md](packaging.md) — conda/meta.yaml boundaries, why there's no in-repo conda build, the Sphinx theme flag
+
+## Q
+
+## R
+
 - [release-workflow.md](release-workflow.md) — why releases across the suite follow a strict dependency order, and the recurring pitfalls that order exists to avoid
+
+## S
+
+## T
+
+## U
+
+## V
+
+## W
+
+## X
+
+## Y
+
+## Z


### PR DESCRIPTION
Lifts this repo from keep-the-why context-schema 0.11.0 to 0.13.2 (current release). Same change in all eight UBS repos.

## What changes

- `.keep-the-why`: `context-schema: 0.13.2`
- `context/index.md`: rebuilt into the fixed letter skeleton — thirty-six level-2 headings `## 0` … `## 9`, `## A` … `## Z`, every topic file under its first letter. Mandatory from schema 0.13.0 on (linter `E205`/`E206`); the migration notes say to do it once, fully, not "next touched". Entries and descriptions are untouched.
- `context/README.md`: the Status line names the fifth value introduced in 0.13.0 (`pending-confirmation`), matching the current wizard template.
- `.github/workflows/ktw-lint.yml`: comments only — the `version:` hint and the ref comment now match the current snippet; since 0.12.0 `@lint-v<version>` pins action and linter together, the old comment said the opposite. Job config unchanged (`@lint-latest`, non-strict).

## What was checked and does not apply

- `id` line (0.13.0 confinement check): `oliver-zehentleitner---<repo>`, fits the allowed alphabet.
- `init: declined` (retired in 0.12.0): not present.
- Rule renumbering: nothing new since 0.11.0.
- 0.12.0 start paths / ephemeral-environment recipe: optional, not adopted here.

## Verification

`ktw-lint 0.13.2.0 --strict .` — 0 errors, 0 warnings before the bump (on 0.11.0) and after (on 0.13.2). Removing one heading from the migrated index produces `E205` as expected, so the new gate is live for this repo.

Migration reference: https://github.com/oliver-zehentleitner/keep-the-why/blob/v0.13.2/skills/keep-the-why/references/migrations.md
